### PR TITLE
remove unneeded babel runtime packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -281,15 +281,6 @@
       "integrity": "sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==",
       "dev": true
     },
-    "@babel/plugin-external-helpers": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.2.0.tgz",
-      "integrity": "sha512-QFmtcCShFkyAsNtdCM3lJPmRe1iB+vPZymlB4LnDIKEBj2yKQLQKtoxXxJ8ePT5fwMl4QGg303p4mB0UsSI2/g==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
@@ -627,18 +618,6 @@
         "regenerator-transform": "^0.13.3"
       }
     },
-    "@babel/plugin-transform-runtime": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz",
-      "integrity": "sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.1"
-      }
-    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
@@ -756,14 +735,6 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-transform-flow-strip-types": "^7.0.0"
-      }
-    },
-    "@babel/runtime": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
-      "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
-      "requires": {
-        "regenerator-runtime": "^0.12.0"
       }
     },
     "@babel/template": {
@@ -4498,11 +4469,6 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
       "version": "0.13.3",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
   "license": "ISC",
   "devDependencies": {
     "@babel/core": "^7.2.2",
-    "@babel/plugin-external-helpers": "^7.2.0",
     "@babel/plugin-proposal-class-properties": "^7.3.0",
-    "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-flow": "^7.0.0",
     "chai": "^4.2.0",
@@ -36,7 +34,5 @@
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2"
   },
-  "dependencies": {
-    "@babel/runtime": "^7.3.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Missed this when removed changed the code to not be `async` in 15b66d33afff7b7665d3d3b83abd930566bbc305.

Removes unneeded babel runtime packages.