### PR TITLE
Publish to GPR after publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "clean": "rm -rf dist",
     "prebuild": "npm run clean && npm run lint && mkdir dist",
     "pretest": "npm run build",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "postpublish": "npm publish --@github:registry='https://npm.pkg.github.com'"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This should publish to the GitHub Package Registry after a successful publish to the npm registry so that this package is available on both registries ✨ 

Ref: https://github.com/github/web-systems/issues/227