### PR TITLE
Don't run scripts when publishing to GPR

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prebuild": "npm run clean && npm run lint && mkdir dist",
     "pretest": "npm run build",
     "prepublishOnly": "npm run build",
-    "postpublish": "npm publish --@github:registry='https://npm.pkg.github.com'"
+    "postpublish": "npm publish --ignore-scripts --@github:registry='https://npm.pkg.github.com'"
   },
   "files": [
     "dist",


### PR DESCRIPTION
When we added the `postpublish` script in #9 we introduced a small issue that would recursively try to publish the package to the GPR registry.

This change will not run any of the pre/post scripts since the pre scripts should have already been run when we published to NPM and then we don't want to run the post scripts when we are publishing to GPR 