### PR TITLE
Track fields not always available in the DOM

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,18 @@ export function persistResumableFields(id: string, options?: PersistOptions): vo
 
   if (fields.length) {
     try {
-      sessionStorage.setItem(key, JSON.stringify(fields))
+      const previouslyStoredFieldsJson = sessionStorage.getItem(key)
+      let allFields: string[][] = fields
+
+      if (previouslyStoredFieldsJson !== null) {
+        const previouslyStoredFields: string[][] = JSON.parse(previouslyStoredFieldsJson)
+        const fieldsNotReplaced: string[][] = previouslyStoredFields.filter(function (oldField) {
+          return !allFields.some(field => field[0] === oldField[0])
+        })
+        allFields = allFields.concat(fieldsNotReplaced)
+      }
+
+      sessionStorage.setItem(key, JSON.stringify(allFields))
     } catch {
       // Ignore browser private mode error.
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,22 +20,21 @@ export function persistResumableFields(id: string, options?: PersistOptions): vo
     }
   }
 
-  const fields = resumables.filter(field => shouldResumeField(field)).map(field => [field.id, field.value])
+  let fields = resumables.filter(field => shouldResumeField(field)).map(field => [field.id, field.value])
 
   if (fields.length) {
     try {
       const previouslyStoredFieldsJson = sessionStorage.getItem(key)
-      let allFields: string[][] = fields
 
       if (previouslyStoredFieldsJson !== null) {
         const previouslyStoredFields: string[][] = JSON.parse(previouslyStoredFieldsJson)
         const fieldsNotReplaced: string[][] = previouslyStoredFields.filter(function (oldField) {
-          return !allFields.some(field => field[0] === oldField[0])
+          return !fields.some(field => field[0] === oldField[0])
         })
-        allFields = allFields.concat(fieldsNotReplaced)
+        fields = fields.concat(fieldsNotReplaced)
       }
 
-      sessionStorage.setItem(key, JSON.stringify(allFields))
+      sessionStorage.setItem(key, JSON.stringify(fields))
     } catch {
       // Ignore browser private mode error.
     }

--- a/test/test.js
+++ b/test/test.js
@@ -13,11 +13,32 @@ describe('session-resume', function () {
 
   describe('restoreResumableFields', function () {
     it('restores fields values from session storage', function () {
-      sessionStorage.setItem('session-resume:test-persist', JSON.stringify([['my-first-field', 'test2']]))
+      sessionStorage.setItem(
+        'session-resume:test-persist',
+        JSON.stringify([
+          ['my-first-field', 'test2'],
+          ['non-existant-field', 'test3']
+        ])
+      )
       restoreResumableFields('test-persist')
 
       assert.equal(document.querySelector('#my-first-field').value, 'test2')
       assert.equal(document.querySelector('#my-second-field').value, 'second-field-value')
+
+      // Some fields we want to restore are not always present in the DOM
+      // and may be added later. We hold onto the values until they're needed.
+      assert.deepEqual(JSON.parse(sessionStorage.getItem('session-resume:test-persist')), [
+        ['non-existant-field', 'test3']
+      ])
+    })
+
+    it('removes the sessionStore key when all the fields were found', function () {
+      sessionStorage.setItem('session-resume:test-persist', JSON.stringify([['my-first-field', 'test2']]))
+      restoreResumableFields('test-persist')
+
+      // Some fields we want to restore are not always present in the DOM
+      // and may be added later. We hold onto the values until they're needed.
+      assert.equal(sessionStorage.getItem('session-resume:test-persist'), null)
     })
 
     it('fires off session:resume events for changed fields', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -67,13 +67,22 @@ describe('session-resume', function () {
 
   describe('persistResumableFields', function () {
     it('persist fields values to session storage', function () {
+      sessionStorage.setItem(
+        'session-resume:test-persist',
+        JSON.stringify([
+          ['my-first-field', 'old data'],
+          ['non-existant-field', 'test3']
+        ])
+      )
       document.querySelector('#my-first-field').value = 'test1'
       document.querySelector('#my-second-field').value = 'test2'
+
       persistResumableFields('test-persist')
 
       assert.deepEqual(JSON.parse(sessionStorage.getItem('session-resume:test-persist')), [
         ['my-first-field', 'test1'],
-        ['my-second-field', 'test2']
+        ['my-second-field', 'test2'],
+        ['non-existant-field', 'test3']
       ])
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,14 @@ describe('session-resume', function () {
 
   describe('restoreResumableFields', function () {
     it('restores fields values from session storage', function () {
+      sessionStorage.setItem('session-resume:test-persist', JSON.stringify([['my-first-field', 'test2']]))
+      restoreResumableFields('test-persist')
+
+      assert.equal(document.querySelector('#my-first-field').value, 'test2')
+      assert.equal(document.querySelector('#my-second-field').value, 'second-field-value')
+    })
+
+    it('leaves unrestored values in session storage', function () {
       sessionStorage.setItem(
         'session-resume:test-persist',
         JSON.stringify([
@@ -20,6 +28,9 @@ describe('session-resume', function () {
           ['non-existant-field', 'test3']
         ])
       )
+      document.querySelector('#my-first-field').value = 'first-field-value'
+      document.querySelector('#my-second-field').value = 'second-field-value'
+
       restoreResumableFields('test-persist')
 
       assert.equal(document.querySelector('#my-first-field').value, 'test2')
@@ -67,13 +78,18 @@ describe('session-resume', function () {
 
   describe('persistResumableFields', function () {
     it('persist fields values to session storage', function () {
-      sessionStorage.setItem(
-        'session-resume:test-persist',
-        JSON.stringify([
-          ['my-first-field', 'old data'],
-          ['non-existant-field', 'test3']
-        ])
-      )
+      document.querySelector('#my-first-field').value = 'test1'
+      document.querySelector('#my-second-field').value = 'test2'
+      persistResumableFields('test-persist')
+
+      assert.deepEqual(JSON.parse(sessionStorage.getItem('session-resume:test-persist')), [
+        ['my-first-field', 'test1'],
+        ['my-second-field', 'test2']
+      ])
+    })
+
+    it('holds onto existing values in the store', function () {
+      sessionStorage.setItem('session-resume:test-persist', JSON.stringify([['non-existant-field', 'test3']]))
       document.querySelector('#my-first-field').value = 'test1'
       document.querySelector('#my-second-field').value = 'test2'
 
@@ -83,6 +99,19 @@ describe('session-resume', function () {
         ['my-first-field', 'test1'],
         ['my-second-field', 'test2'],
         ['non-existant-field', 'test3']
+      ])
+    })
+
+    it('replaces old values with the latest field values', function () {
+      sessionStorage.setItem('session-resume:test-persist', JSON.stringify([['my-first-field', 'old data']]))
+      document.querySelector('#my-first-field').value = 'test1'
+      document.querySelector('#my-second-field').value = 'test2'
+
+      persistResumableFields('test-persist')
+
+      assert.deepEqual(JSON.parse(sessionStorage.getItem('session-resume:test-persist')), [
+        ['my-first-field', 'test1'],
+        ['my-second-field', 'test2']
       ])
     })
   })


### PR DESCRIPTION
There are some cases where fields may not immediately be present in the DOM and added later. In these cases, when the fields are restored, those not present in the DOM are not restored (because they simply don't exist yet), however we completely remove all the stored fields' values from the session store. This means that fields that are added later will not have a chance to restore their data.

This change holds onto field values for fields that weren't able to be located in case that field is added to the DOM later and can then be restored.

If a field never appears, it would stay in the session storage until the tab is closed. Because session storage is scoped to the tab, automatically cleared when the tab is closed, and has a 5 MB limit, this is unlikely to cause memory bloat problems.