### PR TITLE
Make sure to access `sessionStorage` in a `try` block

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,15 @@ type PersistOptions = {
 export function persistResumableFields(id: string, options?: PersistOptions): void {
   const selector = options?.selector ?? '.js-session-resumable'
   const keyPrefix = options?.keyPrefix ?? 'session-resume:'
-  const storage = options?.storage ?? sessionStorage
+
+  let storage
+  try {
+    storage = options?.storage ?? sessionStorage
+  } catch {
+    // Ignore browser private mode error and return early
+    return
+  }
+
   const key = `${keyPrefix}${id}`
   const resumables = []
 
@@ -50,7 +58,15 @@ type RestoreOptions = {keyPrefix?: string; storage?: Pick<Storage, 'getItem' | '
 
 export function restoreResumableFields(id: string, options?: RestoreOptions): void {
   const keyPrefix = options?.keyPrefix ?? 'session-resume:'
-  const storage = options?.storage ?? sessionStorage
+
+  let storage
+  try {
+    storage = options?.storage ?? sessionStorage
+  } catch {
+    // Ignore browser private mode error and return early
+    return
+  }
+
   const key = `${keyPrefix}${id}`
   let fields
 


### PR DESCRIPTION
In https://github.com/github/session-resume/pull/38 we allowed callers
to pass in their own storage implementation. We accidentally leaked a `window.sessionStorage` access outside of a `try` block, though,
and this could lead to errors when users have cookies disabled or are
in private mode.

I've chosen to keep the other `try/catch` blocks to minimize changes.