### PR TITLE
ns/add/checked support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The `restoreResumableFields(id: string, options)` function supports optional con
 The `persistResumableFields(id: string, options)` function supports optional configurations:
 
 * `storage:` - [`Storage`][] instance (defaults to [`window.sessionStorage`][])
-* `storageFilter:` - `(field: HTMLInputElement | HTMLTextAreaElement) => boolean` predicate to determine whether or not to store a field (defaults to `(field) => field.value !== field.defaultValue`)
+* `storageFilter:` - `(field: HTMLInputElement | HTMLTextAreaElement) => boolean` predicate to determine whether or not to store a field (defaults to `(field) => field.checked !== field.defaultChecked)` for checkbox and radio buttons, `(field) => field.value !== field.defaultValue` otherwise)
 * `keyPrefix:` - `string` prepended onto the storage key (defaults to `"session-resume"`)
 * `scope:` - `ParentNode` used to query field elements (defaults to `document`)
 * `selector:` - `string` used to query field elements (defaults to `".js-session-resumable"`)

--- a/examples/index.html
+++ b/examples/index.html
@@ -60,8 +60,8 @@
   </form>
 
   <script type="module">
-    import {persistResumableFields, restoreResumableFields, setForm} from '../dist/index.js'
-    // import {persistResumableFields, restoreResumableFields, setForm} from 'https://unpkg.com/@github/session-resume/dist/index.js'
+    // import {persistResumableFields, restoreResumableFields, setForm} from '../dist/index.js'
+    import {persistResumableFields, restoreResumableFields, setForm} from 'https://unpkg.com/@github/session-resume/dist/index.js'
     
     // Listen for all form submit events and to see if their default submission
     // behavior is invoked.

--- a/examples/index.html
+++ b/examples/index.html
@@ -38,8 +38,8 @@
     <fieldset>
         <legend>Checkboxes</legend>
         <div>
-            <input type="checkbox" id="ice-cream-vanilla" name="ice-cream" value="vanilla" class="js-session-resumable" />
-            <label for="ice-cream-vanilla">Vanilla</label><br>
+            <input type="checkbox" id="ice-cream-vanilla" name="ice-cream" value="vanilla" class="js-session-resumable" checked />
+            <label for="ice-cream-vanilla">Vanilla (checked)</label><br>
             <input type="checkbox" id="ice-cream-chocolate" name="ice-cream" value="chocolate" class="js-session-resumable" />
             <label for="ice-cream-chocolate">Chocolate</label><br>
             <input type="checkbox" id="ice-cream-strawberry" name="ice-cream" value="strawberry" class="js-session-resumable" />
@@ -60,8 +60,8 @@
   </form>
 
   <script type="module">
-    // import {persistResumableFields, restoreResumableFields, setForm} from '../dist/index.js'
-    import {persistResumableFields, restoreResumableFields, setForm} from 'https://unpkg.com/@github/session-resume/dist/index.js'
+    import {persistResumableFields, restoreResumableFields, setForm} from '../dist/index.js'
+    // import {persistResumableFields, restoreResumableFields, setForm} from 'https://unpkg.com/@github/session-resume/dist/index.js'
     
     // Listen for all form submit events and to see if their default submission
     // behavior is invoked.

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>session-resume demo</title>
+  <style>
+    fieldset {
+      margin-bottom: 1em;
+    }
+  </style>
+</head>
+<body>
+  <h1>session-resume</h1>
+
+  <h2>Test by filling out the form and then refreshing the page or <a href="https://github.com">navigating away</a> and back.</h2>
+  
+  <form>
+    <p>
+        <label>Text input<br>
+            <input type="text" id="new-title" class="js-session-resumable"/>
+        </label>
+    </p>
+    <p>
+        <label>Email<br>
+            <input type="email" id="new-email" class="js-session-resumable"/>
+        </label>
+    </p>
+    <p>
+        <label>Number<br>
+            <input type="number" id="new-phone" class="js-session-resumable"/>
+        </label>
+    </p>
+    <p>
+        <label>Textarea<br>
+            <textarea id="new-comment" class="js-session-resumable"></textarea>
+        </label>
+    </p>
+    <fieldset>
+        <legend>Checkboxes</legend>
+        <div>
+            <input type="checkbox" id="ice-cream-vanilla" name="ice-cream" value="vanilla" class="js-session-resumable" />
+            <label for="ice-cream-vanilla">Vanilla</label><br>
+            <input type="checkbox" id="ice-cream-chocolate" name="ice-cream" value="chocolate" class="js-session-resumable" />
+            <label for="ice-cream-chocolate">Chocolate</label><br>
+            <input type="checkbox" id="ice-cream-strawberry" name="ice-cream" value="strawberry" class="js-session-resumable" />
+            <label for="ice-cream-strawberry">Strawberry</label>
+        </div>
+    </fieldset>
+    <fieldset>
+        <legend>Radio</legend>
+        <div>
+            <input type="radio" id="cake" name="cake-pie" value="cake" class="js-session-resumable" />
+            <label for="cake">Cake</label><br>
+            <input type="radio" id="pie" name="cake-pie" value="pie" class="js-session-resumable" />
+            <label for="pie">Pie</label>
+        </div>
+    </fieldset>
+
+    <button id="save-data" type="button">Set sessionStorage</button>
+  </form>
+
+  <script type="module">
+    import {persistResumableFields, restoreResumableFields, setForm} from '../dist/index.js'
+    // import {persistResumableFields, restoreResumableFields, setForm} from 'https://unpkg.com/@github/session-resume/dist/index.js'
+    
+    // Listen for all form submit events and to see if their default submission
+    // behavior is invoked.
+    window.addEventListener('submit', setForm, {capture: true})
+
+    // Resume field content on regular page loads.
+    window.addEventListener('pageshow', function() {
+        restoreResumableFields('session-resume-demo')
+    })
+
+    // Persist resumable fields when page is unloaded
+    window.addEventListener('pagehide', function() {
+        persistResumableFields('session-resume-demo')
+    })
+
+    document.addEventListener('click', function(event) {
+        if (event.target.id === 'save-data') {
+            persistResumableFields('session-resume-demo')
+        }
+    })
+  </script>
+</body>
+</html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export function restoreResumableFields(id: string, options?: RestoreOptions): vo
       const field = document.getElementById(fieldId)
       if (field && (field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement)) {
         if (field instanceof HTMLInputElement && (field.type === 'checkbox' || field.type === 'radio')) {
-          field.checked = true
+          field.checked = !field.defaultChecked
           changedFields.push(field)
         } else if (field.value === field.defaultValue) {
           field.value = value

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,12 @@
 let submittedForm: HTMLFormElement | null = null
 
 function shouldResumeField(field: HTMLInputElement | HTMLTextAreaElement, filter: StorageFilter): boolean {
-  return !!field.id && filter(field) && field.form !== submittedForm
+  return (
+    !!field.id &&
+    (field.value !== field.defaultValue ||
+      (field instanceof HTMLInputElement && field.checked !== field.defaultChecked)) &&
+    field.form !== submittedForm
+  )
 }
 
 function valueIsUnchanged(field: HTMLInputElement | HTMLTextAreaElement): boolean {
@@ -112,7 +117,10 @@ export function restoreResumableFields(id: string, options?: RestoreOptions): vo
     if (document.dispatchEvent(resumeEvent)) {
       const field = document.getElementById(fieldId)
       if (field && (field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement)) {
-        if (field.value === field.defaultValue) {
+        if (field instanceof HTMLInputElement && (field.type === 'checkbox' || field.type === 'radio')) {
+          field.checked = true
+          changedFields.push(field)
+        } else if (field.value === field.defaultValue) {
           field.value = value
           changedFields.push(field)
         }

--- a/test/test.js
+++ b/test/test.js
@@ -97,14 +97,28 @@ describe('session-resume', function () {
       assert.deepEqual(fieldsRestored, {'my-first-field': 'test2'})
     })
 
-    it('fires off change for changed fields', function (done) {
-      for (const input of document.querySelectorAll('input')) {
+    it('fires off change for changed input[type=text] fields', function (done) {
+      for (const input of document.querySelectorAll('input[type=text]')) {
         input.addEventListener('change', function (event) {
           done(assert.equal(event.target.id, 'my-first-field'))
         })
       }
 
       sessionStorage.setItem('session-resume:test-persist', JSON.stringify([['my-first-field', 'test2']]))
+      restoreResumableFields('test-persist')
+    })
+
+    it('fires off change for changed input[type=checkbox] fields', function (done) {
+      for (const input of document.querySelectorAll('input[type=checkbox]')) {
+        input.addEventListener('change', function (event) {
+          done(assert.equal(event.target.id, 'my-first-checkbox'))
+        })
+      }
+
+      sessionStorage.setItem(
+        'session-resume:test-persist',
+        JSON.stringify([['my-first-checkbox', 'first-checkbox-value']])
+      )
       restoreResumableFields('test-persist')
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -6,8 +6,8 @@ describe('session-resume', function () {
     // eslint-disable-next-line github/no-inner-html
     document.body.innerHTML = `
       <form>
-        <input id="my-first-field" value="first-field-value" class="js-session-resumable" />
-        <input id="my-second-field" value="second-field-value" class="js-session-resumable" />
+        <input id="my-first-field" type="text" value="first-field-value" class="js-session-resumable" />
+        <input id="my-second-field" type="text" value="second-field-value" class="js-session-resumable" />
         <input id="my-first-checkbox" type="checkbox" value="first-checkbox-value" class="js-session-resumable" />
         <input id="my-second-checkbox" type="checkbox" value="second-checkbox-value" class="js-session-resumable" />
         <input id="my-checked-checkbox" type="checkbox" value="checked-checkbox-value" class="js-session-resumable" checked />
@@ -129,7 +129,7 @@ describe('session-resume', function () {
       document.querySelector('#my-second-field').value = 'test2'
       persistResumableFields('test-persist')
 
-      assert.deepEqual(JSON.parse(sessionStorage.getItem('session-resume:test-persist')), [
+      assert.includeDeepMembers(JSON.parse(sessionStorage.getItem('session-resume:test-persist')), [
         ['my-first-field', 'test1'],
         ['my-second-field', 'test2']
       ])
@@ -151,7 +151,7 @@ describe('session-resume', function () {
 
       persistResumableFields('test-persist', {storage: fakeStorage})
 
-      assert.deepEqual(JSON.parse(fakeStorage.getItem('session-resume:test-persist')), [
+      assert.includeDeepMembers(JSON.parse(fakeStorage.getItem('session-resume:test-persist')), [
         ['my-first-field', 'test1'],
         ['my-second-field', 'test2']
       ])
@@ -164,7 +164,7 @@ describe('session-resume', function () {
 
       persistResumableFields('test-persist')
 
-      assert.deepEqual(JSON.parse(sessionStorage.getItem('session-resume:test-persist')), [
+      assert.includeDeepMembers(JSON.parse(sessionStorage.getItem('session-resume:test-persist')), [
         ['my-first-field', 'test1'],
         ['my-second-field', 'test2'],
         ['non-existant-field', 'test3']
@@ -178,7 +178,7 @@ describe('session-resume', function () {
 
       persistResumableFields('test-persist')
 
-      assert.deepEqual(JSON.parse(sessionStorage.getItem('session-resume:test-persist')), [
+      assert.includeDeepMembers(JSON.parse(sessionStorage.getItem('session-resume:test-persist')), [
         ['my-first-field', 'test1'],
         ['my-second-field', 'test2']
       ])

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,7 @@ describe('session-resume', function () {
         <input id="my-second-field" value="second-field-value" class="js-session-resumable" />
         <input id="my-first-checkbox" type="checkbox" value="first-checkbox-value" class="js-session-resumable" />
         <input id="my-second-checkbox" type="checkbox" value="second-checkbox-value" class="js-session-resumable" />
+        <input id="my-checked-checkbox" type="checkbox" value="checked-checkbox-value" class="js-session-resumable" checked />
       </form>
     `
     window.addEventListener('submit', sessionStorage.setForm, {capture: true})
@@ -21,7 +22,8 @@ describe('session-resume', function () {
         'session-resume:test-persist',
         JSON.stringify([
           ['my-first-field', 'test2'],
-          ['my-first-checkbox', 'first-checkbox-value']
+          ['my-first-checkbox', 'first-checkbox-value'],
+          ['my-checked-checkbox', 'checked-checkbox-value']
         ])
       )
       restoreResumableFields('test-persist')
@@ -30,6 +32,7 @@ describe('session-resume', function () {
       assert.equal(document.querySelector('#my-second-field').value, 'second-field-value')
       assert.equal(document.querySelector('#my-first-checkbox').checked, true)
       assert.equal(document.querySelector('#my-second-checkbox').checked, false)
+      assert.equal(document.querySelector('#my-checked-checkbox').checked, false)
     })
 
     it('uses a Storage object when provided as an option', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,8 @@ describe('session-resume', function () {
       <form>
         <input id="my-first-field" value="first-field-value" class="js-session-resumable" />
         <input id="my-second-field" value="second-field-value" class="js-session-resumable" />
+        <input id="my-first-checkbox" type="checkbox" value="first-checkbox-value" class="js-session-resumable" />
+        <input id="my-second-checkbox" type="checkbox" value="second-checkbox-value" class="js-session-resumable" />
       </form>
     `
     window.addEventListener('submit', sessionStorage.setForm, {capture: true})
@@ -15,11 +17,19 @@ describe('session-resume', function () {
 
   describe('restoreResumableFields', function () {
     it('restores fields values from session storage by default', function () {
-      sessionStorage.setItem('session-resume:test-persist', JSON.stringify([['my-first-field', 'test2']]))
+      sessionStorage.setItem(
+        'session-resume:test-persist',
+        JSON.stringify([
+          ['my-first-field', 'test2'],
+          ['my-first-checkbox', 'first-checkbox-value']
+        ])
+      )
       restoreResumableFields('test-persist')
 
       assert.equal(document.querySelector('#my-first-field').value, 'test2')
       assert.equal(document.querySelector('#my-second-field').value, 'second-field-value')
+      assert.equal(document.querySelector('#my-first-checkbox').checked, true)
+      assert.equal(document.querySelector('#my-second-checkbox').checked, false)
     })
 
     it('uses a Storage object when provided as an option', function () {


### PR DESCRIPTION
- Add support for checkboxes and radio buttons
- Add example file
- Add a checkbox test
- Default to the public built file for the test page
- Account for default checked checkboxes
- Keep the external script for test page by default
- Incorporate checkables into `storageFilter:`
- fix tests
