### PR TITLE
Encourage `visibilitychange` over `pageshow` and `pagehide`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ function getPageID() {
 // behavior is invoked.
 window.addEventListener('submit', setForm, {capture: true})
 
-// Resume field content on regular page loads.
-window.addEventListener('pageshow', function() {
-  restoreResumableFields(getPageID())
-})
-
-// Persist resumable fields when page is unloaded
-window.addEventListener('pagehide', function() {
-  persistResumableFields(getPageID())
+window.addEventListener('visibilitychange', function() {
+  if (document.visibilityState === 'visible') {
+    // Resume field content on regular page loads.
+    restoreResumableFields(getPageID())
+  } else {
+    // Persist resumable fields when page is unloaded
+    persistResumableFields(getPageID())
+  }
 })
 ```
 


### PR DESCRIPTION
According to the MDN documentation for [pagehide][]:

> The best event to use to signal the end of a user's session is the
> `visibilitychange` event. In browsers that don't support
> `visibilitychange` the `pagehide` event is the next-best alternative.

This commit changes the documentation to encourage users to listen for [visibilitychange][] events, then check for the
[Document.visibilityState][] to indicate whether the tab is shown or hidden.

[pagehide]: https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event#usage_notes
[visibilitychange]: https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event
[Document.visibilityState]: https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState